### PR TITLE
PMM-6401 update victoriametrics for reading prom data (#171)

### DIFF
--- a/rhel/SPECS/victoriametrics.spec
+++ b/rhel/SPECS/victoriametrics.spec
@@ -13,16 +13,15 @@
 %global repo            VictoriaMetrics
 %global provider_prefix %{provider}.%{provider_tld}/%{project}/%{repo}
 %global import_path     %{provider_prefix}
-%global commit          be6ae4b5e755df57db135b77e749067c8822a96a
-%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global commit          pmm-6401-v1.44.0
 
 Name:           percona-victoriametrics
-Version:        1.40.1
+Version:        1.44.0
 Release:        1%{?dist}
 Summary:        VictoriaMetrics monitoring solution and time series database
 License:        Apache-2.0
 URL:            https://%{provider_prefix}
-Source0:        https://%{provider_prefix}/archive/%{commit}/%{repo}-%{shortcommit}.tar.gz
+Source0:        https://%{provider_prefix}/archive/%{commit}.tar.gz
 
 
 %description
@@ -34,7 +33,7 @@ Source0:        https://%{provider_prefix}/archive/%{commit}/%{repo}-%{shortcomm
 
 
 %build
-export PKG_TAG=%{shortcommit}
+export PKG_TAG=%{commit}
 export BUILDINFO_TAG=%{commit}
 export USER=builder
 
@@ -55,5 +54,8 @@ install -D -p -m 0755 ./bin/vmalert-pure %{buildroot}%{_sbindir}/vmalert
 
 
 %changelog
-* Wed Sep 4 2020 Aliaksandr Valialkin <valyala@victoriametrics.com> - 1.40.1-1
+* Tue Oct 13 2020 Aliaksandr Valialkin <valyala@victoriametrics.com> - 1.44.0-1
+- PMM-6401 upgrade victoriametrics for reading Prometheus data files
+
+* Fri Sep 4 2020 Aliaksandr Valialkin <valyala@victoriametrics.com> - 1.40.1-1
 - PMM-6389 add victoriametrics and vmalert binaries


### PR DESCRIPTION
* PMM-6401 update VictoriaMetrics for reading Prometheus data

Fetch VictoriaMetrics sources from https://github.com/VictoriaMetrics/VictoriaMetrics/tree/pmm-6401-read-prometheus-data-files .

* PMM-6401 Fix invalid dates

* PMM-6401 fix url for source download

* PMM-6401 update VictoriaMetrics from v1.43.0 to v1.44.0